### PR TITLE
Add the ability to have custom, non-core menu items appear in the menu

### DIFF
--- a/app/code/community/Webguys/CustomerNavigation/Block/Account/Navigation.php
+++ b/app/code/community/Webguys/CustomerNavigation/Block/Account/Navigation.php
@@ -1,26 +1,115 @@
 <?php 
 
-class Webguys_CustomerNavigation_Block_Account_Navigation extends Mage_Customer_Block_Account_Navigation {
+class Webguys_CustomerNavigation_Block_Account_Navigation extends Mage_Customer_Block_Account_Navigation
+{
+    /** @var array */
+    protected $configuredLinks = array(
+        'account',
+        'account_edit',
+        'address_book',
+        'orders',
+        'billing_agreements',
+        'recurring_profiles',
+        'reviews',
+        'tags',
+        'newsletter',
+        'oauth_customer_tokens',
+        'downloadable_products',
+        'wishlist'
+    );
 
-	public function getLinks()
+    /**
+     * @inheritDoc
+     */
+    public function getLinks()
     {
-    	$pre_links 	  = $this->_links;
-    	$tmp_links    = array(); 
-		$this->_links = array();
-		
-		foreach ($pre_links as $_link) {
-			if( Mage::getStoreConfig( 'customernavigation/settings/show_' . $_link->getName() ) ) {
-				$tmp_links[ Mage::getStoreConfig( 'customernavigation/reorder/position_' . $_link->getName() ) ] = $_link;				
-			}            	
-		}
-		
-		ksort( $tmp_links );
-		
-		foreach ($tmp_links as $key=>$_link) {
-			if( Mage::getStoreConfig( 'customernavigation/settings/show_' . $_link->getName() ) ) {
-				$this->addLink($_link->getName(), $_link->getPath(), $_link->getLabel());				
-			}            	
-		}
-		return $this->_links;
+        $preLinks = $this->_links;
+        $tmpLinks = array();
+        $this->_links = array();
+
+        $order = 150;
+        foreach ($preLinks as $link) {
+            $isConfiguredLink = $this->isConfiguredLink($link);
+            // Add any core links configured to show in the module
+            if ($isConfiguredLink && $this->isConfiguredToShow($link)) {
+                $position = $this->getConfigPosition($link);
+                $tmpLinks[$position] = $link;
+            }
+            // Add any custom links added via layout XML
+            if (!$isConfiguredLink) {
+                $tmpLinks[$order] = $link;
+                $order += 10;
+            }
+        }
+
+        // Sort the new list
+        ksort($tmpLinks);
+
+        foreach ($tmpLinks as $position => $link) {
+            $isConfiguredLink = $this->isConfiguredLink($link);
+            // Add any core links configured to show in the module
+            if ($isConfiguredLink && $this->isConfiguredToShow($link)) {
+                $this->addLink($link->getName(), $link->getPath(), $link->getLabel());
+            }
+            // Add any custom links added via layout XML
+            if (!$isConfiguredLink) {
+                $this->addLink($link->getName(), $link->getPath(), $link->getLabel());
+            }
+        }
+
+        return $this->_links;
+    }
+
+    /**
+     * Determine if the given link is configured to be shown.
+     *
+     * @param Varien_Object $link
+     *
+     * @return mixed
+     */
+    protected function isConfiguredToShow(Varien_Object $link)
+    {
+        return Mage::getStoreConfig(
+            sprintf('customernavigation/settings/show_%s', $this->getFormattedName($link))
+        );
+    }
+
+    /**
+     * Get the configured position for the given link.
+     *
+     * @param Varien_Object $link
+     *
+     * @return mixed
+     */
+    protected function getConfigPosition(Varien_Object $link)
+    {
+        return Mage::getStoreConfig(
+            sprintf('customernavigation/reorder/position_%s', $this->getFormattedName($link))
+        );
+    }
+
+    /**
+     * Determine if the given link is a "configured" link.
+     *
+     * @param Varien_Object $link
+     *
+     * @return bool
+     */
+    protected function isConfiguredLink(Varien_Object $link)
+    {
+        $needle = $this->getFormattedName($link);
+        return (in_array($needle, $this->configuredLinks));
+    }
+
+    /**
+     * Get the formatted name e.g. my_link_name.
+     *
+     * @param Varien_Object $link
+     *
+     * @return mixed
+     */
+    protected function getFormattedName(Varien_Object $link)
+    {
+        return str_replace(' ', '_', strtolower($link->getName()));
     }
 }

--- a/app/code/community/Webguys/CustomerNavigation/Helper/Data.php
+++ b/app/code/community/Webguys/CustomerNavigation/Helper/Data.php
@@ -1,5 +1,6 @@
 <?php
 
-class Webguys_CustomerNavigation_Helper_Data extends Mage_Core_Helper_Abstract {
+class Webguys_CustomerNavigation_Helper_Data extends Mage_Core_Helper_Abstract
+{
     
 }

--- a/app/code/community/Webguys/CustomerNavigation/etc/config.xml
+++ b/app/code/community/Webguys/CustomerNavigation/etc/config.xml
@@ -66,6 +66,7 @@
                 <show_tags>false</show_tags>
                 <show_wishlist>false</show_wishlist>
                 <show_downloadable_products>false</show_downloadable_products>
+                <show_oauth_customer_tokens>false</show_oauth_customer_tokens>
 				<show_newsletter>false</show_newsletter>
 			</settings>
 			<reorder>	
@@ -79,7 +80,8 @@
                 <position_tags>80</position_tags>
                 <position_wishlist>90</position_wishlist>
                 <position_downloadable_products>100</position_downloadable_products>
-				<position_newsletter>110</position_newsletter>
+                <position_oauth_customer_tokens>110</position_oauth_customer_tokens>
+				<position_newsletter>120</position_newsletter>
             </reorder>
         </customernavigation>
     </default>    

--- a/app/code/community/Webguys/CustomerNavigation/etc/system.xml
+++ b/app/code/community/Webguys/CustomerNavigation/etc/system.xml
@@ -119,11 +119,21 @@
                             <show_in_store>1</show_in_store>
                         </show_downloadable_products>
 
+                        <show_oauth_customer_tokens translate="label">
+                            <label>My Applications</label>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_yesno</source_model>
+                            <sort_order>110</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                        </show_oauth_customer_tokens>
+
                         <show_newsletter translate="label">
                             <label>Newsletter</label>
                             <frontend_type>select</frontend_type>
                             <source_model>adminhtml/system_config_source_yesno</source_model>
-                            <sort_order>110</sort_order>
+                            <sort_order>120</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
@@ -240,11 +250,21 @@
                             <show_in_store>1</show_in_store>
                         </position_downloadable_products>
 
+                        <position_oauth_customer_tokens translate="label comment">
+                            <label>My Applications</label>
+                            <comment>Make sure this value is unique</comment>
+                            <frontend_type>text</frontend_type>
+                            <sort_order>115</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                        </position_oauth_customer_tokens>
+
                         <position_newsletter translate="label comment">
                             <label>Newsletter</label>
                             <comment>Make sure this value is unique</comment>
                             <frontend_type>text</frontend_type>
-                            <sort_order>115</sort_order>
+                            <sort_order>125</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>


### PR DESCRIPTION
Hi, currently if you have any modules added via the community or local code pools, they won't appear in the menu as the menu will only deal with links declared in system.xml to be stored in configuration. This update allows all menu links by default and allows you to show/hide core links.

Also, it add 'My Applications' to the list of configurable menu links.